### PR TITLE
Travis file & validation tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "commitcoffee",
+  "description": "A list of places friendly to social oriented geeks",
+  "scripts": {
+    "test": "python validateplaces.py"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xando/commitcoffee"
+  },
+  "author": "Sebastian Pawluś",
+  "bugs": {
+    "url": "https://github.com/xando/commitcoffee/issues"
+  }
+}

--- a/validateplaces.py
+++ b/validateplaces.py
@@ -3,6 +3,7 @@ import json
 import glob
 import argparse
 import itertools
+import sys
 
 
 OK, WRONG = True, False
@@ -36,6 +37,7 @@ def parse_places(files):
             places.extend(data)
         else:
             print("File '%s' is invalid: %s" % (json_file_name, data))
+            sys.exit(1)
 
     return places
 


### PR DESCRIPTION
Travis defines a failing test as one which returns a non-zero error code.

I updated the validate script to return 1 when an invalid JSON file is found.

There's also a travis file & package.json which describe the tests (`npm test` just delegates to `python validateplaces.py`)
